### PR TITLE
Implement nonogram library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_INSTALL_PREFIX ${PROJECT_SOURCE_DIR})
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+include(CTest)
+include(DownloadGTestGMock.cmake)
+
+add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+
+add_subdirectory(nonogram)

--- a/DownloadGTestGMock.cmake
+++ b/DownloadGTestGMock.cmake
@@ -1,0 +1,31 @@
+set(NONOGRAM_PROJECT "googletest")
+set(NONOGRAM_GIT_REPOSITORY "https://github.com/google/googletest.git")
+set(NONOGRAM_GIT_TAG "master")
+set(UPDATE_DISCONNECTED_IF_AVAILABLE "UPDATE_DISCONNECTED 1")
+set(NONOGRAM_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/${NONOGRAM_PROJECT}-download")
+set(NONOGRAM_SOURCE_DIR "${CMAKE_BINARY_DIR}/${NONOGRAM_PROJECT}-src")
+set(NONOGRAM_BINARY_DIR "${CMAKE_BINARY_DIR}/${NONOGRAM_PROJECT}-build")
+
+set(${NONOGRAM_PROJECT}_SOURCE_DIR "${NONOGRAM_SOURCE_DIR}")
+set(${NONOGRAM_PROJECT}_BINARY_DIR "${NONOGRAM_BINARY_DIR}")
+
+configure_file(GTestGMock.CMakeLists.cmake.in
+               "${NONOGRAM_DOWNLOAD_DIR}/CMakeLists.txt"
+)
+
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
+                    -D "CMAKE_MAKE_PROGRAM:FILE=${CMAKE_MAKE_PROGRAM}"
+                    .
+                RESULT_VARIABLE result
+                WORKING_DIRECTORY "${NONOGRAM_DOWNLOAD_DIR}"
+)
+if(result)
+    message(FATAL_ERROR "CMake step for ${NONOGRAM_PROJECT} failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+                RESULT_VARIABLE result
+                WORKING_DIRECTORY "${NONOGRAM_DOWNLOAD_DIR}"
+)
+if(result)
+    message(FATAL_ERROR "Build step for ${NONOGRAM_PROJECT} failed: ${result}")
+endif()

--- a/GTestGMock.CMakeLists.cmake.in
+++ b/GTestGMock.CMakeLists.cmake.in
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.10.0)
+
+project(${NONOGRAM_PROJECT}-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(${NONOGRAM_PROJECT}-download
+                    GIT_REPOSITORY ${NONOGRAM_GIT_REPOSITORY}
+                    GIT_TAG ${NONOGRAM_GIT_TAG}
+                    ${UPDATE_DISCONNECTED_IF_AVAILABLE}
+                    SOURCE_DIR "${NONOGRAM_SOURCE_DIR}"
+                    BINARY_DIR "${NONOGRAM_BINARY_DIR}"
+                    CONFIGURE_COMMAND   ""
+                    BUILD_COMMAND       ""
+                    INSTALL_COMMAND     ""
+                    TEST_COMMAND        ""
+)

--- a/nonogram/CMakeLists.txt
+++ b/nonogram/CMakeLists.txt
@@ -1,0 +1,25 @@
+project(nonogram)
+
+add_definitions( -DBOOST_LOG_DYN_LINK)
+find_package(Boost 1.65.0 COMPONENTS log REQUIRED)
+find_package(Threads)
+
+include_directories(include
+                    src/incl
+)
+
+add_library(${PROJECT_NAME} STATIC src/impl/nonogram.cpp
+                                   src/impl/nonogram_factory.cpp
+                                   src/impl/nonogram_log.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC  include
+                                           PRIVATE src/incl
+                                                   ${Boost_INCLUDE_DIR}
+)
+
+target_link_libraries(${PROJECT_NAME} ${Boost_LOG_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+
+install(TARGETS nonogram DESTINATION "bin")
+
+add_subdirectory(test)

--- a/nonogram/include/i_nonogram.hpp
+++ b/nonogram/include/i_nonogram.hpp
@@ -1,0 +1,86 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_INCLUDE_I_NONOGRAM_HPP_
+#define NONOGRAM_GAME_NONOGRAM_INCLUDE_I_NONOGRAM_HPP_
+
+#include <cstdint>
+#include <vector>
+
+#include "nonogram_cell_state.hpp"
+
+/**
+ * @brief The class describes interface for nonogram game object.
+ */
+
+class INonogram {
+public:
+  virtual ~INonogram() = default;
+
+  /**
+   * @brief The method returns state of the nonogram field.
+   *
+   * @return State of the nonogram field.
+   */
+  virtual const std::vector<std::vector<NonogramCellState>> &
+  GetField() const = 0;
+
+  /**
+   * @brief The method returns count of columns of the nonogram.
+   *
+   * @return Number of columns of the nonogram.
+   */
+  virtual const uint8_t GetColumns() const = 0;
+
+  /**
+   * @brief The method returns count of columns of the nonogram.
+   *
+   * @return Number of rows of the nonogram.
+   */
+  virtual const uint8_t GetRows() const = 0;
+
+  /**
+   * @brief The method returns state of the nonogram cell.
+   *
+   * @param row Number of the row of the nonogram. Count starts from 0.
+   *
+   * @param column Number of the column of the nonogram. Count starts from 0.
+   *
+   * @return State of the nonogram cell.
+   */
+  virtual const NonogramCellState GetNonogramCellState(const uint8_t row,
+                                           const uint8_t column) const = 0;
+
+  /**
+   * @brief The method sets state to the nonogram cell.
+   *
+   * @param row Number of the row of the nonogram. Count starts from 0.
+   *
+   * @param column Number of the column of the nonogram. Count starts from 0.
+   */
+  virtual void SetNonogramCellState(const uint8_t row, const uint8_t column,
+                                    const NonogramCellState state) = 0;
+
+  /**
+   * @brief The method returns vector of numbers according to which the nonogram
+   * row should be filled.
+   *
+   * @param row Number of the row of the nonogram. Count starts from 0.
+   *
+   * @return Vector of the numbers of the row of the nonogram.
+   */
+  virtual const std::vector<uint8_t> &
+  GetRowNumbers(const uint8_t row) const = 0;
+
+  /**
+   * @brief The method returns vector of numbers according to which the nonogram
+   * column should be filled.
+   *
+   * @param column Number of the column of the nonogram. Count starts from 0.
+   *
+   * @return Vector of the numbers of the column of the nonogram.
+   */
+  virtual const std::vector<uint8_t> &
+  GetColumnNumbers(const uint8_t column) const = 0;
+};
+
+#endif // NONOGRAM_GAME_NONOGRAM_INCLUDE_I_NONOGRAM_HPP_

--- a/nonogram/include/nonogram_cell_state.hpp
+++ b/nonogram/include/nonogram_cell_state.hpp
@@ -1,0 +1,17 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_INCLUDE_NONOGRAM_CELL_STATE_HPP_
+#define NONOGRAM_GAME_NONOGRAM_INCLUDE_NONOGRAM_CELL_STATE_HPP_
+
+/**
+ * @brief The purpose of the enum is to indicate state of each cell of the
+ * nonogram.
+ */
+
+enum class NonogramCellState {
+  kEmpty = 0, /**< The value indicates that there is no sign in the cell*/
+  kMarked,    /**< The value indicates that there is mark in the cell*/
+  kCrossed,   /**< The value indicates that there is no mark in the cell*/
+};
+
+#endif // NONOGRAM_GAME_NONOGRAM_INCLUDE_NONOGRAM_CELL_STATE_HPP_

--- a/nonogram/include/nonogram_factory.hpp
+++ b/nonogram/include/nonogram_factory.hpp
@@ -1,0 +1,19 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_INCLUDE_NONOGRAM_FACTORY_HPP_
+#define NONOGRAM_GAME_NONOGRAM_INCLUDE_NONOGRAM_FACTORY_HPP_
+
+#include <memory>
+#include <vector>
+
+#include "i_nonogram.hpp"
+
+/**
+ * @brief The purpose of the function is to create the nonogram object.
+ */
+
+std::shared_ptr<INonogram>
+MakeNonogram(const std::vector<std::vector<uint8_t>> &row_numbers,
+             const std::vector<std::vector<uint8_t>> &column_numbers);
+
+#endif // NONOGRAM_GAME_NONOGRAM_INCLUDE_NONOGRAM_FACTORY_HPP_

--- a/nonogram/src/impl/nonogram.cpp
+++ b/nonogram/src/impl/nonogram.cpp
@@ -1,0 +1,73 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#include <stdexcept>
+
+#include <boost/log/trivial.hpp>
+
+#include "nonogram.hpp"
+#include "nonogram_log.hpp"
+
+Nonogram::Nonogram(const std::vector<std::vector<uint8_t>> &row_numbers,
+                   const std::vector<std::vector<uint8_t>> &column_numbers,
+                   const std::shared_ptr<INonogramLog> log)
+    : rows_{static_cast<uint8_t>(row_numbers.size())},
+      columns_{static_cast<uint8_t>(column_numbers.size())},
+      field_{rows_, {columns_, NonogramCellState::kEmpty}},
+      row_numbers_{row_numbers}, column_numbers_{column_numbers}, log_{log} {
+  log_->LogInfo("Constructing nonogram object.");
+}
+
+const std::vector<std::vector<NonogramCellState>> &Nonogram::GetField() const {
+  log_->LogInfo("Returning field.");
+  return field_;
+}
+
+const uint8_t Nonogram::GetColumns() const {
+  log_->LogInfo("Returning columns.");
+  return columns_;
+}
+
+const uint8_t Nonogram::GetRows() const {
+  log_->LogInfo("Returning rows.");
+  return rows_;
+}
+
+const NonogramCellState
+Nonogram::GetNonogramCellState(const uint8_t row, const uint8_t column) const {
+  log_->LogInfo("Returning state of cell.");
+  if (row < 0 || row >= rows_ || column < 0 || column >= columns_) {
+    throw std::runtime_error("The value of row or(and) column is not correct.");
+  } else {
+    return field_[row][column];
+  }
+}
+
+void Nonogram::SetNonogramCellState(const uint8_t row, const uint8_t column,
+                                    NonogramCellState state) {
+  log_->LogInfo("Setting new state to the cell.");
+  if (row < 0 || row >= rows_ || column < 0 || column >= columns_) {
+    throw std::runtime_error("The value of row or(and) column is not correct.");
+  } else {
+    field_[row][column] = state;
+  }
+  return;
+}
+
+const std::vector<uint8_t> &Nonogram::GetRowNumbers(const uint8_t row) const {
+  log_->LogInfo("Getting numbers for the row.");
+  if (row < 0 || row >= rows_) {
+    throw std::runtime_error("The value of row is not correct.");
+  } else {
+    return row_numbers_[row];
+  }
+}
+
+const std::vector<uint8_t> &
+Nonogram::GetColumnNumbers(const uint8_t column) const {
+  log_->LogInfo("Getting numbers for the column.");
+  if (column < 0 || column >= columns_) {
+    throw std::runtime_error("The value of row or(and) column is not correct.");
+  } else {
+    return column_numbers_[column];
+  }
+}

--- a/nonogram/src/impl/nonogram_factory.cpp
+++ b/nonogram/src/impl/nonogram_factory.cpp
@@ -1,0 +1,15 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#include "nonogram_factory.hpp"
+
+#include <boost/log/trivial.hpp>
+
+#include "nonogram.hpp"
+#include "nonogram_log.hpp"
+
+std::shared_ptr<INonogram>
+MakeNonogram(const std::vector<std::vector<uint8_t>> &row_numbers,
+             const std::vector<std::vector<uint8_t>> &column_numbers) {
+  return std::make_shared<Nonogram>(row_numbers, column_numbers,
+                                    std::make_shared<NonogramLog>());
+}

--- a/nonogram/src/impl/nonogram_log.cpp
+++ b/nonogram/src/impl/nonogram_log.cpp
@@ -1,0 +1,9 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#include "nonogram_log.hpp"
+
+#include <boost/log/trivial.hpp>
+
+void NonogramLog::LogInfo(const std::string &log_message) const {
+  BOOST_LOG_TRIVIAL(info) << log_message;
+}

--- a/nonogram/src/incl/i_nonogram_log.hpp
+++ b/nonogram/src/incl/i_nonogram_log.hpp
@@ -1,0 +1,23 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_SRC_INCL_I_NONOGRAM_HPP_
+#define NONOGRAM_GAME_NONOGRAM_SRC_INCL_I_NONOGRAM_HPP_
+
+#include <string>
+
+/**
+ * @brief The purpose of the interface is to wrapp the logging system and
+ * symplify changing and mocking it.
+ */
+class INonogramLog {
+public:
+  virtual ~INonogramLog() = default;
+  /**
+   * @brief The method logs on info level.
+   *
+   * @param log_message The message string that should be logged.
+   */
+  virtual void LogInfo(const std::string &log_message) const = 0;
+};
+
+#endif // NONOGRAM_GAME_NONOGRAM_SRC_INCL_I_NONOGRAM_HPP_

--- a/nonogram/src/incl/nonogram.hpp
+++ b/nonogram/src/incl/nonogram.hpp
@@ -1,0 +1,82 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_SRC_INCL_NONOGRAM_HPP_
+#define NONOGRAM_GAME_NONOGRAM_SRC_INCL_NONOGRAM_HPP_
+
+#include <memory>
+#include <vector>
+
+#include "i_nonogram.hpp"
+#include "i_nonogram_log.hpp"
+
+/**
+ * @brief Implementation of the INonogram interface
+ */
+class Nonogram : public INonogram {
+public:
+  /**
+   * @brief Creates nonogram object from vectors with numbers according to which
+   * the nonogram should be solved.
+   *
+   * @param row_numbers vector of row numbers vectors.
+   *
+   * @param column_numbers vector of column numbers vectors.
+   *
+   * @param log The logger object.
+   */
+  Nonogram(const std::vector<std::vector<uint8_t>> &row_numbers,
+           const std::vector<std::vector<uint8_t>> &column_numbers,
+           const std::shared_ptr<INonogramLog> log);
+
+  const std::vector<std::vector<NonogramCellState>> &GetField() const override;
+
+  const uint8_t GetColumns() const override;
+
+  const uint8_t GetRows() const override;
+
+  const NonogramCellState
+  GetNonogramCellState(const uint8_t row, const uint8_t column) const override;
+
+  void SetNonogramCellState(const uint8_t row, const uint8_t column,
+                            NonogramCellState state) override;
+
+  const std::vector<uint8_t> &GetRowNumbers(const uint8_t row) const override;
+
+  const std::vector<uint8_t> &
+  GetColumnNumbers(const uint8_t column) const override;
+
+private:
+  /**
+   * @brief The number of the nonogram rows.
+   */
+  const uint8_t rows_;
+
+  /**
+   * @brief The number of the nonogram columnss.
+   */
+  const uint8_t columns_;
+
+  /**
+   * @brief The member contains the nonogram state.
+   */
+  std::vector<std::vector<NonogramCellState>> field_;
+
+  /**
+   * @brief The member contains row numbers vectors according to which the
+   * nonogram should be solved.
+   */
+  const std::vector<std::vector<uint8_t>> row_numbers_;
+
+  /**
+   * @brief The member contains column numbers vectors according to which the
+   * nonogram should be solved.
+   */
+  const std::vector<std::vector<uint8_t>> column_numbers_;
+
+  /**
+   * @brief The logger object
+   */
+  const std::shared_ptr<INonogramLog> log_;
+};
+
+#endif // NONOGRAM_GAME_NONOGRAM_SRC_INCL_NONOGRAM_HPP_

--- a/nonogram/src/incl/nonogram_log.hpp
+++ b/nonogram/src/incl/nonogram_log.hpp
@@ -1,0 +1,20 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_SRC_INCL_NONOGRAM_LOG_HPP_
+#define NONOGRAM_GAME_NONOGRAM_SRC_INCL_NONOGRAM_LOG_HPP_
+
+#include <string>
+
+#include "i_nonogram_log.hpp"
+
+/**
+ * @brief The implementation of the nonogram_log class
+ */
+
+class NonogramLog : public INonogramLog {
+public:
+  NonogramLog() = default;
+  void LogInfo(const std::string &log_message) const override;
+};
+
+#endif // NONOGRAM_GAME_NONOGRAM_SRC_INCL_NONOGRAM_LOG_HPP_

--- a/nonogram/test/CMakeLists.txt
+++ b/nonogram/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+project(unit_tests_nonogram)
+
+set(LIB_NAME nonogram_mocks)
+
+add_library(${LIB_NAME} INTERFACE)
+target_include_directories(${LIB_NAME} INTERFACE ${PROJECT_SOURCE_DIR}/mocks_include)
+target_link_libraries(${LIB_NAME} INTERFACE nonogram)
+set(PRIVATE_HEADERS $<TARGET_PROPERTY:nonogram,INCLUDE_DIRECTORIES>)
+
+add_executable(${PROJECT_NAME} nonogram_test.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PRIVATE ${PRIVATE_HEADERS})
+
+target_link_libraries(${PROJECT_NAME} gtest_main
+                                      gmock_main
+                                      ${LIB_NAME}
+)

--- a/nonogram/test/mocks_include/mock_nonogram.hpp
+++ b/nonogram/test/mocks_include/mock_nonogram.hpp
@@ -1,0 +1,25 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_TEST_MOCKS_INCLUDE_MOCK_NONOGRAM_HPP_
+#define NONOGRAM_GAME_NONOGRAM_TEST_MOCKS_INCLUDE_MOCK_NONOGRAM_HPP_
+
+#include "gmock/gmock.h"
+
+#include "i_nonogram.hpp"
+
+class MockNonogram : public INonogram {
+  MOCK_CONST_METHOD0(GetField,
+                     const std::vector<std::vector<NonogramCellState>> &());
+  MOCK_CONST_METHOD0(GetColumns, const uint8_t());
+  MOCK_CONST_METHOD0(GetRows, const uint8_t());
+  MOCK_CONST_METHOD2(GetNonogramCellState,
+                     const NonogramCellState(const uint8_t, const uint8_t));
+  MOCK_METHOD3(SetNonogramCellState,
+               void(const uint8_t, const uint8_t, const NonogramCellState));
+  MOCK_CONST_METHOD1(GetRowNumbers,
+                     const std::vector<uint8_t> &(const uint8_t));
+  MOCK_CONST_METHOD1(GetColumnNumbers,
+                     const std::vector<uint8_t> &(const uint8_t));
+};
+
+#endif // NONOGRAM_GAME_NONOGRAM_TEST_MOCKS_INCLUDE_MOCK_NONOGRAM_HPP_

--- a/nonogram/test/mocks_include/mock_nonogram_log.hpp
+++ b/nonogram/test/mocks_include/mock_nonogram_log.hpp
@@ -1,0 +1,16 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_TEST_MOCKS_INCLUDE_MOCK_NONOGRAM_HPP_
+#define NONOGRAM_GAME_NONOGRAM_TEST_MOCKS_INCLUDE_MOCK_NONOGRAM_HPP_
+
+#include <string>
+
+#include "gmock/gmock.h"
+
+#include "i_nonogram_log.hpp"
+
+class MockNonogramLog : public INonogramLog {
+  MOCK_CONST_METHOD1(LogInfo, void(const std::string &));
+};
+
+#endif // NONOGRAM_GAME_NONOGRAM_TEST_MOCKS_INCLUDE_MOCK_NONOGRAM_HPP_

--- a/nonogram/test/nonogram_test.cpp
+++ b/nonogram/test/nonogram_test.cpp
@@ -1,0 +1,167 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#include "mock_nonogram_log.hpp"
+#include "nonogram.hpp"
+
+#include "gtest/gtest.h"
+
+using ::testing::NiceMock;
+
+TEST(NonogramTest, GetRowsTest) {
+  std::vector<std::vector<uint8_t>> r, empty_columns;
+  std::vector<uint8_t> r_1{1, 2, 3, 4};
+  r.push_back(r_1);
+  auto nonogram =
+      Nonogram(r, empty_columns, std::make_shared<NiceMock<MockNonogramLog>>());
+  EXPECT_EQ(nonogram.GetRows(), 1);
+
+  // Empty rows
+  std::vector<std::vector<uint8_t>> empty_rows;
+  auto empty_nonogram = Nonogram(empty_rows, empty_columns,
+                                 std::make_shared<NiceMock<MockNonogramLog>>());
+  EXPECT_EQ(empty_nonogram.GetRows(), 0);
+
+  // 10 rows
+  std::vector<std::vector<uint8_t>> rows_10;
+  for (uint8_t i = 0; i < 10; ++i) {
+    rows_10.push_back(std::vector<uint8_t>());
+  }
+  auto nonogram_10_rows = Nonogram(
+      rows_10, empty_columns, std::make_shared<NiceMock<MockNonogramLog>>());
+  EXPECT_EQ(nonogram_10_rows.GetRows(), 10);
+}
+
+TEST(NonogramTest, GetColumnsTest) {
+  std::vector<std::vector<uint8_t>> empty_rows, empty_columns, columns_1,
+      columns_10;
+  columns_1.push_back(std::vector<uint8_t>());
+  for (uint8_t i = 0; i < 10; ++i) {
+    columns_10.push_back(std::vector<uint8_t>());
+  }
+
+  auto empty_nonogram = Nonogram(empty_rows, empty_columns,
+                                 std::make_shared<NiceMock<MockNonogramLog>>());
+  auto nonogram_1 = Nonogram(empty_rows, columns_1,
+                             std::make_shared<NiceMock<MockNonogramLog>>());
+  auto nonogram_10 = Nonogram(empty_rows, columns_10,
+                              std::make_shared<NiceMock<MockNonogramLog>>());
+
+  EXPECT_EQ(empty_nonogram.GetColumns(), 0);
+  EXPECT_EQ(nonogram_1.GetColumns(), 1);
+  EXPECT_EQ(nonogram_10.GetColumns(), 10);
+}
+
+TEST(NonogramTest, GetRowNumbersTest) {
+  std::vector<std::vector<uint8_t>> empty_columns, rows;
+
+  // Test empty rows.
+  auto empty_nonogram = Nonogram(rows, empty_columns,
+                                 std::make_shared<NiceMock<MockNonogramLog>>());
+  EXPECT_THROW(empty_nonogram.GetRowNumbers(0), std::runtime_error);
+
+  // Test one entry rows.
+  rows.push_back(std::vector<uint8_t>({1, 2, 3, 4}));
+  auto one_entry_nonogram = Nonogram(
+      rows, empty_columns, std::make_shared<NiceMock<MockNonogramLog>>());
+  EXPECT_EQ(one_entry_nonogram.GetRowNumbers(0),
+            std::vector<uint8_t>({1, 2, 3, 4}));
+
+  // Test many entry rows.
+  rows.push_back(std::vector<uint8_t>({5, 6, 7, 8}));
+  auto many_entry_nonogram = Nonogram(
+      rows, empty_columns, std::make_shared<NiceMock<MockNonogramLog>>());
+  EXPECT_NE(many_entry_nonogram.GetRowNumbers(1),
+            std::vector<uint8_t>({1, 2, 3, 4}));
+  EXPECT_EQ(many_entry_nonogram.GetRowNumbers(1),
+            std::vector<uint8_t>({5, 6, 7, 8}));
+}
+
+TEST(NonogramTest, GetColumnNumbersTest) {
+  std::vector<std::vector<uint8_t>> columns, empty_rows;
+
+  // Test empty columns.
+  auto empty_nonogram = Nonogram(empty_rows, columns,
+                                 std::make_shared<NiceMock<MockNonogramLog>>());
+  EXPECT_THROW(empty_nonogram.GetColumnNumbers(0), std::runtime_error);
+
+  // Test one entry rows.
+  columns.push_back(std::vector<uint8_t>({1, 2, 3, 4}));
+  auto one_entry_nonogram = Nonogram(
+      empty_rows, columns, std::make_shared<NiceMock<MockNonogramLog>>());
+  EXPECT_EQ(one_entry_nonogram.GetColumnNumbers(0),
+            std::vector<uint8_t>({1, 2, 3, 4}));
+
+  // Test many entry rows.
+  columns.push_back(std::vector<uint8_t>({5, 6, 7, 8}));
+  auto many_entry_nonogram = Nonogram(
+      empty_rows, columns, std::make_shared<NiceMock<MockNonogramLog>>());
+  EXPECT_NE(many_entry_nonogram.GetColumnNumbers(1),
+            std::vector<uint8_t>({1, 2, 3, 4}));
+  EXPECT_EQ(many_entry_nonogram.GetColumnNumbers(1),
+            std::vector<uint8_t>({5, 6, 7, 8}));
+}
+
+TEST(NonogramTest, GetFieldTest) {
+  // Test empty field
+  std::vector<std::vector<uint8_t>> empty_rows, empty_columns;
+  auto empty_nonogram = Nonogram(empty_rows, empty_columns,
+                                 std::make_shared<NiceMock<MockNonogramLog>>());
+  auto empty_field = std::vector<std::vector<NonogramCellState>>();
+  EXPECT_EQ(empty_nonogram.GetField(), empty_field);
+
+  // Test nonempty field
+  std::vector<std::vector<uint8_t>> nonempty_rows{{1}}, nonempty_columns{{1}};
+  auto nonempty_nonogram =
+      Nonogram(nonempty_rows, nonempty_columns,
+               std::make_shared<NiceMock<MockNonogramLog>>());
+  nonempty_nonogram.SetNonogramCellState(0, 0, NonogramCellState::kMarked);
+  EXPECT_EQ(nonempty_nonogram.GetField()[0][0], NonogramCellState::kMarked);
+}
+
+TEST(NonogramTest, GetNonogramCellStateTest) {
+  // Test throw
+  std::vector<std::vector<uint8_t>> empty_rows, empty_columns;
+  auto empty_nonogram = Nonogram(empty_rows, empty_columns,
+                                 std::make_shared<NiceMock<MockNonogramLog>>());
+  EXPECT_THROW(empty_nonogram.GetNonogramCellState(0, 0), std::runtime_error);
+
+  // Test correct state
+  std::vector<std::vector<uint8_t>> nonempty_rows{{1}}, nonempty_columns{{1}};
+  auto nonempty_nonogram =
+      Nonogram(nonempty_rows, nonempty_columns,
+               std::make_shared<NiceMock<MockNonogramLog>>());
+  nonempty_nonogram.SetNonogramCellState(0, 0, NonogramCellState::kMarked);
+  EXPECT_EQ(nonempty_nonogram.GetNonogramCellState(0, 0),
+            NonogramCellState::kMarked);
+  nonempty_nonogram.SetNonogramCellState(0, 0, NonogramCellState::kCrossed);
+  EXPECT_EQ(nonempty_nonogram.GetNonogramCellState(0, 0),
+            NonogramCellState::kCrossed);
+  nonempty_nonogram.SetNonogramCellState(0, 0, NonogramCellState::kEmpty);
+  EXPECT_EQ(nonempty_nonogram.GetNonogramCellState(0, 0),
+            NonogramCellState::kEmpty);
+}
+
+TEST(NonogramTest, SetNonogramCellStateTest) {
+  // Test throw
+  std::vector<std::vector<uint8_t>> empty_rows, empty_columns;
+  auto empty_nonogram = Nonogram(empty_rows, empty_columns,
+                                 std::make_shared<NiceMock<MockNonogramLog>>());
+  EXPECT_THROW(
+      empty_nonogram.SetNonogramCellState(0, 0, NonogramCellState::kMarked),
+      std::runtime_error);
+
+  // Test correct state
+  std::vector<std::vector<uint8_t>> nonempty_rows{{1}}, nonempty_columns{{1}};
+  auto nonempty_nonogram =
+      Nonogram(nonempty_rows, nonempty_columns,
+               std::make_shared<NiceMock<MockNonogramLog>>());
+  nonempty_nonogram.SetNonogramCellState(0, 0, NonogramCellState::kMarked);
+  EXPECT_EQ(nonempty_nonogram.GetNonogramCellState(0, 0),
+            NonogramCellState::kMarked);
+  nonempty_nonogram.SetNonogramCellState(0, 0, NonogramCellState::kCrossed);
+  EXPECT_EQ(nonempty_nonogram.GetNonogramCellState(0, 0),
+            NonogramCellState::kCrossed);
+  nonempty_nonogram.SetNonogramCellState(0, 0, NonogramCellState::kEmpty);
+  EXPECT_EQ(nonempty_nonogram.GetNonogramCellState(0, 0),
+            NonogramCellState::kEmpty);
+}


### PR DESCRIPTION
In order to implement the nonogram library interface (i_nonogram.hpp),
factory for creating an object of the nonogram class and other usefull
stuff (nonogram_cell_state) were added and implemented. Also added a
wrapper for logging in order to separate third party libraries from the
code and added simple loging to the nonogram implementation. In order to
control the quality of code and further changes the nonogram
implementation was covered by simple unit tests. Also mock classes for
both interfaces were added.
It should compile by g++.