### PR TITLE
Add nonogram gui project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,3 +12,4 @@ include(DownloadGTestGMock.cmake)
 add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
 
 add_subdirectory(nonogram)
+add_subdirectory(nonogram_gui)

--- a/nonogram/src/impl/nonogram.cpp
+++ b/nonogram/src/impl/nonogram.cpp
@@ -49,6 +49,22 @@ void Nonogram::SetNonogramCellState(const uint8_t row, const uint8_t column,
     throw std::runtime_error("The value of row or(and) column is not correct.");
   } else {
     field_[row][column] = state;
+    std::string state_string = "";
+    switch (state) {
+    case NonogramCellState::kMarked:
+      state_string = "Marked";
+      break;
+    case NonogramCellState::kCrossed:
+      state_string = "Crossed";
+      break;
+    case NonogramCellState::kEmpty:
+      state_string = "Empty";
+      break;
+    default:
+      state_string = "Unknown";
+    }
+    log_->LogInfo("New state of the cell (" + std::to_string(row) + "," +
+                  std::to_string(column) + ") is: " + state_string);
   }
   return;
 }

--- a/nonogram_gui/CMakeLists.txt
+++ b/nonogram_gui/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.10.0)
+
+project(nonogram_gui)
+
+add_definitions(-DBOOST_LOG_DYN_LINK)
+find_package(Boost 1.65.0 COMPONENTS log REQUIRED)
+find_package(Threads)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+find_package(Qt5 COMPONENTS Widgets Qml Quick REQUIRED)
+
+qt5_add_resources(QT_RESOURCES qml.qrc)
+
+include_directories(include
+                    src/incl
+)
+
+add_executable(${PROJECT_NAME} src/impl/main.cpp
+                               src/impl/nonogram_rect_model.cpp
+                               src/impl/nonogram_wrapper.cpp
+                               src/impl/column_numbers_model.cpp
+                               src/impl/row_numbers_model.cpp
+                               src/impl/nonogram_field_model.cpp
+                               src/incl/nonogram_rect_model.hpp
+                               src/incl/nonogram_wrapper.hpp
+                               src/incl/column_numbers_model.hpp
+                               src/incl/row_numbers_model.hpp
+                               src/incl/nonogram_field_model.hpp
+                               ${QT_RESOURCES}
+)
+
+target_link_libraries(${PROJECT_NAME} nonogram
+                                      ${Boost_LOG_LIBRARY}
+                                      ${CMAKE_THREAD_LIBS_INIT}
+                                      Qt5::Widgets
+                                      Qt5::Qml
+                                      Qt5::Quick
+)

--- a/nonogram_gui/qml.qrc
+++ b/nonogram_gui/qml.qrc
@@ -1,0 +1,14 @@
+<RCC>
+        <qresource prefix="/">
+                   <file>resources/main.qml</file>
+                   <file>resources/NonogramDelegate.qml</file>
+                   <file>resources/NonogramCanvas.qml</file>
+                   <file>resources/ColumnNumbersDelegate.qml</file>
+                   <file>resources/RowNumbersDelegate.qml</file>
+                   <file>resources/NonogramRectDelegate.qml</file>
+                   <file>resources/ColumnNumbersRectangle.qml</file>
+                   <file>resources/NonogramFieldRectangle.qml</file>
+                   <file>resources/RowNumbersRectangle.qml</file>
+                   <file>resources/scripts.js</file>
+        </qresource>
+</RCC>

--- a/nonogram_gui/resources/ColumnNumbersDelegate.qml
+++ b/nonogram_gui/resources/ColumnNumbersDelegate.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.12
+
+import NonogramModel 1.0
+
+import "qrc:/resources"
+
+Item {
+    Rectangle {
+        width: cell_dimension
+        height: cell_dimension
+        border.color: "#000000"
+        border.width: 1
+        color: "#A9A9A9"
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: model.column_number_text
+        }
+    }
+}

--- a/nonogram_gui/resources/ColumnNumbersRectangle.qml
+++ b/nonogram_gui/resources/ColumnNumbersRectangle.qml
@@ -1,0 +1,35 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.12
+
+import NonogramModel 1.0
+
+import "qrc:/resources"
+
+Rectangle {
+    anchors.top: parent.top
+    anchors.right: parent.right
+    anchors.margins: 1
+
+    width: model.field_width * cell_dimension
+    height: model.max_column_numbers * cell_dimension
+
+    border.color: "#000000"
+    border.width: 1
+
+    GridView {
+        id: column_numbers_grid_view
+        model: ColumnNumbersModel {
+            id: column_numbers_model
+            nonogram: nonogramWrapper
+        }
+
+        anchors.fill: parent
+
+        cellWidth: cell_dimension
+        cellHeight: cell_dimension
+
+        delegate: ColumnNumbersDelegate {
+            id: column_numbers_delegate
+        }
+    }
+}

--- a/nonogram_gui/resources/NonogramCanvas.qml
+++ b/nonogram_gui/resources/NonogramCanvas.qml
@@ -1,0 +1,31 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.12
+
+import NonogramModel 1.0
+
+import "scripts.js" as NonogramScripts
+
+Canvas {
+    property var canvas_parent_view
+    anchors.fill: parent
+    onPaint: {
+        canvas_parent_view.width = parent_cell_dimension * model.column_count;
+        canvas_parent_view.height = parent_cell_dimension * model.row_count;
+
+        var canvas_context = getContext("2d");
+        switch(model.state) {
+        case NonogramFieldModel.Empty: {
+            NonogramScripts.drawEmpty(canvas_context, 0, 0, parent_cell_dimension, parent_cell_dimension);
+            break;
+        }
+        case NonogramFieldModel.Marked: {
+            NonogramScripts.drawMarked(canvas_context, 0, 0, parent_cell_dimension, parent_cell_dimension);
+            break;
+        }
+        case NonogramFieldModel.Crossed: {
+            NonogramScripts.drawCross(canvas_context, "#000000", 0, 0, parent_cell_dimension, parent_cell_dimension);
+            break;
+        }
+        }
+    }
+}

--- a/nonogram_gui/resources/NonogramDelegate.qml
+++ b/nonogram_gui/resources/NonogramDelegate.qml
@@ -1,0 +1,39 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.12
+
+import NonogramModel 1.0
+
+Item {
+    property var parent_cell_dimension
+    property var parent_view
+
+    anchors.margins: 50
+    height: parent_cell_dimension
+    width: parent_cell_dimension
+
+    Rectangle {
+        anchors.fill: parent
+        NonogramCanvas{
+            id: delegate_canvas
+            canvas_parent_view: parent_view
+        }
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onClicked: {
+                switch(mouse.button) {
+                case Qt.LeftButton: {
+                    model.state = (model.state == NonogramFieldModel.Marked ? NonogramFieldModel.Empty : NonogramFieldModel.Marked);
+                    break;
+                }
+                case Qt.RightButton: {
+                    model.state = (model.state == NonogramFieldModel.Crossed ? NonogramFieldModel.Empty :
+                                   NonogramFieldModel.Crossed);
+                    break;
+                }
+                }
+                delegate_canvas.requestPaint();
+            }
+        }
+    }
+}

--- a/nonogram_gui/resources/NonogramFieldRectangle.qml
+++ b/nonogram_gui/resources/NonogramFieldRectangle.qml
@@ -1,0 +1,36 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.12
+
+import NonogramModel 1.0
+
+import "qrc:/resources"
+
+Rectangle {
+    property var column_numbers_prop
+    id: nonogram_field
+
+    anchors.top: column_numbers_prop.bottom
+    anchors.right: column_numbers_prop.right
+
+    width: model.field_width * cell_dimension
+    height: model.field_height * cell_dimension
+
+    border.color: "#000000"
+    border.width: 1
+    color: "#ffffff"
+
+    GridView {
+        id: main_grid_view
+        model: NonogramFieldModel {
+            id: nonogram_field_model
+            nonogram: nonogramWrapper
+        }
+
+        cellWidth: cell_dimension
+        cellHeight: cell_dimension
+        delegate: NonogramDelegate {
+            parent_cell_dimension: cell_dimension
+            parent_view: main_grid_view
+        }
+    }
+}

--- a/nonogram_gui/resources/NonogramRectDelegate.qml
+++ b/nonogram_gui/resources/NonogramRectDelegate.qml
@@ -1,0 +1,35 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.12
+
+import NonogramModel 1.0
+
+import "qrc:/resources"
+
+Item {
+    Rectangle {
+        x: 10
+        y: 10
+
+        width: (model.max_row_numbers + model.field_width) * cell_dimension + 2
+        height: (model.max_column_numbers + model.field_height) * cell_dimension + 2
+
+        color: "#ffffff"
+        border.color: "#000000"
+        border.width: 1
+
+        ColumnNumbersRectangle {
+            id: column_numbers
+        }
+
+        NonogramFieldRectangle {
+            id: nonogram_field
+            column_numbers_prop: column_numbers
+        }
+
+        RowNumbersRectangle {
+            id: row_numbers
+            column_numbers_prop: column_numbers
+            nonogram_field_prop: nonogram_field
+        }
+    }
+}

--- a/nonogram_gui/resources/RowNumbersDelegate.qml
+++ b/nonogram_gui/resources/RowNumbersDelegate.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.12
+
+import NonogramModel 1.0
+
+import "qrc:/resources"
+
+Item {
+    Rectangle {
+        width: cell_dimension
+        height: cell_dimension
+        border.color: "#000000"
+        border.width: 1
+        color: "#A9A9A9"
+        Text {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: model.row_number_text
+        }
+    }
+}

--- a/nonogram_gui/resources/RowNumbersRectangle.qml
+++ b/nonogram_gui/resources/RowNumbersRectangle.qml
@@ -1,0 +1,38 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.12
+
+import NonogramModel 1.0
+
+import "qrc:/resources"
+
+Rectangle {
+    property var column_numbers_prop
+    property var nonogram_field_prop
+    id: row_numbers
+
+    anchors.top: column_numbers_prop.bottom
+    anchors.right: nonogram_field_prop.left
+
+    width: model.max_row_numbers * cell_dimension
+    height: model.field_height * cell_dimension
+
+    border.color: "#000000"
+    border.width: 1
+
+    GridView {
+        id: row_numbers_grid_view
+        model: RowNumbersModel {
+            id: row_numbers_model
+            nonogram: nonogramWrapper
+        }
+
+        anchors.fill: parent
+
+        cellWidth: cell_dimension
+        cellHeight: cell_dimension
+
+        delegate: RowNumbersDelegate {
+            id: row_numbers_delegate
+        }
+    }
+}

--- a/nonogram_gui/resources/main.qml
+++ b/nonogram_gui/resources/main.qml
@@ -1,0 +1,26 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.12
+
+import NonogramModel 1.0
+
+import "qrc:/resources"
+
+ApplicationWindow {
+    visible: true
+    title: qsTr("Nonogram GUI")
+    width: 700
+    height: 500
+
+    property var cell_dimension: 20
+
+    ListView{
+        anchors.margins: 2
+        model: NonogramRectModel {
+            nonogram: nonogramWrapper
+        }
+
+        delegate: NonogramRectDelegate {
+            id: nonogram_rect_delegate
+        }
+    }
+}

--- a/nonogram_gui/resources/scripts.js
+++ b/nonogram_gui/resources/scripts.js
@@ -1,0 +1,37 @@
+function drawCross(context, color, x_start, y_start, x_end, y_end) {
+    context.fillStyle = Qt.rgba(0.6, 0.6, 0.6, 1);
+    context.fillRect(x_start, y_start, x_end, y_end);
+
+    context.fillStyle = Qt.rgba(1, 1, 1, 1);
+    context.fillRect(x_start + 1, y_start + 1, x_end - 2, y_end - 2);
+
+    context.strokeStyle = context.createPattern(color, Qt.SolidPattern);
+
+    context.beginPath();
+    context.moveTo(x_start, y_start);
+    context.lineTo(x_end, y_end);
+    context.closePath();
+    context.stroke();
+
+    context.beginPath();
+    context.moveTo(x_end, y_start);
+    context.lineTo(x_start, y_end);
+    context.closePath();
+    context.stroke();
+}
+
+function drawEmpty(context, x_start, y_start, x_end, y_end) {
+    context.fillStyle = Qt.rgba(0.6, 0.6, 0.6, 1);
+    context.fillRect(x_start, y_start, x_end, y_end);
+
+    context.fillStyle = Qt.rgba(1, 1, 1, 1);
+    context.fillRect(x_start + 1, y_start + 1, x_end - 2, y_end - 2);
+}
+
+function drawMarked(context, x_start, y_start, x_end, y_end) {
+    context.fillStyle = Qt.rgba(0.6, 0.6, 0.6, 1);
+    context.fillRect(x_start, y_start, x_end, y_end);
+
+    context.fillStyle = Qt.rgba(0, 0, 0, 1);
+    context.fillRect(x_start + 1, y_start + 1, x_end - 2, y_end - 2);
+}

--- a/nonogram_gui/src/impl/column_numbers_model.cpp
+++ b/nonogram_gui/src/impl/column_numbers_model.cpp
@@ -1,0 +1,64 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#include "column_numbers_model.hpp"
+
+#include <QString>
+
+ColumnNumbersModel::ColumnNumbersModel(QObject *parent)
+    : QAbstractListModel(parent), nonogram_{nullptr} {}
+
+int ColumnNumbersModel::rowCount(const QModelIndex &parent) const {
+  if (parent.isValid()) {
+    return 0;
+  }
+
+  return max_column_numbers_ * column_numbers_.size();
+}
+
+QVariant ColumnNumbersModel::data(const QModelIndex &index, int role) const {
+  if (!index.isValid()) {
+    return QVariant();
+  }
+
+  switch (role) {
+  case MaxColumnNumbersRole:
+    return max_column_numbers_;
+  case FieldWidthRole:
+    return static_cast<quint8>(column_numbers_.size());
+  case ColumnNumberTextRole: {
+    auto row = index.row() / column_numbers_.size();
+    auto column = index.row() % column_numbers_.size();
+    auto max_column_size = column_numbers_[column].size();
+    return (max_column_numbers_ - row) > max_column_size
+               ? ""
+               : QString::number(
+                     column_numbers_[column][max_column_numbers_ - row - 1]);
+  }
+  default:
+    return QVariant();
+  }
+}
+
+QHash<int, QByteArray> ColumnNumbersModel::roleNames() const {
+  QHash<int, QByteArray> roles = QAbstractListModel::roleNames();
+
+  roles[MaxColumnNumbersRole] = "max_column_numbers";
+  roles[FieldWidthRole] = "field_width";
+  roles[ColumnNumberTextRole] = "column_number_text";
+
+  return roles;
+}
+
+NonogramWrapper *ColumnNumbersModel::nonogram() const { return nonogram_; }
+
+void ColumnNumbersModel::setNonogram(NonogramWrapper *nonogram) {
+  nonogram_ = nonogram;
+
+  auto field_width = nonogram_->GetFieldWidth();
+
+  max_column_numbers_ = nonogram_->GetMaxColumnNumbers();
+
+  for (size_t i = 0; i < field_width; ++i) {
+    column_numbers_.push_back(nonogram_->getNonogram()->GetColumnNumbers(i));
+  }
+}

--- a/nonogram_gui/src/impl/main.cpp
+++ b/nonogram_gui/src/impl/main.cpp
@@ -1,0 +1,60 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+
+#include <cstdint>
+#include <vector>
+
+#include "column_numbers_model.hpp"
+#include "nonogram_factory.hpp"
+#include "nonogram_field_model.hpp"
+#include "nonogram_rect_model.hpp"
+#include "nonogram_wrapper.hpp"
+#include "row_numbers_model.hpp"
+
+int main(int argc, char *argv[]) {
+  std::vector<std::vector<uint8_t>> row_numbers({{4, 3, 6},
+                                                 {2, 1, 2, 2, 1, 2},
+                                                 {2, 1, 2, 1, 3, 1, 3, 2},
+                                                 {1, 2, 2, 4, 2, 1},
+                                                 {1, 2, 2, 1, 1, 3, 1},
+                                                 {1, 3, 1, 2, 1, 1, 1},
+                                                 {1, 1, 1, 2, 2, 1},
+                                                 {2, 2, 6, 2, 2},
+                                                 {2, 2, 1, 1, 2, 2},
+                                                 {5, 3, 3, 6}}),
+      column_numbers(
+          {{6},          {2, 2},       {2, 2},    {1, 1, 1}, {1, 1, 3, 1},
+           {1, 1, 1, 1}, {2, 3, 3},    {1, 1, 1}, {5},       {1, 2, 1},
+           {3, 2},       {1, 1, 1, 1}, {1, 2, 2}, {1, 1, 2}, {6, 1, 1},
+           {1, 2, 2},    {3},          {1, 1, 1}, {3, 2},    {1, 5, 1},
+           {1, 4},       {1, 1},       {2, 2},    {2, 2},    {6}});
+  auto nonogram = MakeNonogram(row_numbers, column_numbers);
+  NonogramWrapper nonogram_wrapper(nonogram);
+
+  QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  QGuiApplication app(argc, argv);
+
+  qmlRegisterType<NonogramRectModel>("NonogramModel", 1, 0,
+                                     "NonogramRectModel");
+  qmlRegisterType<ColumnNumbersModel>("NonogramModel", 1, 0,
+                                      "ColumnNumbersModel");
+  qmlRegisterType<RowNumbersModel>("NonogramModel", 1, 0, "RowNumbersModel");
+  qmlRegisterType<NonogramFieldModel>("NonogramModel", 1, 0,
+                                      "NonogramFieldModel");
+  qmlRegisterUncreatableType<NonogramWrapper>(
+      "NonogramModel", 1, 0, "NonogramWrapper",
+      QStringLiteral("NonogramWrapper should not be created in QML"));
+
+  QQmlApplicationEngine engine;
+  engine.rootContext()->setContextProperty(QStringLiteral("nonogramWrapper"),
+                                           &nonogram_wrapper);
+  engine.load(QUrl(QLatin1String("qrc:resources/main.qml")));
+  if (engine.rootObjects().isEmpty()) {
+    return -1;
+  }
+
+  return app.exec();
+}

--- a/nonogram_gui/src/impl/nonogram_field_model.cpp
+++ b/nonogram_gui/src/impl/nonogram_field_model.cpp
@@ -1,0 +1,114 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#include "nonogram_field_model.hpp"
+
+NonogramFieldModel::NonogramFieldModel(QObject *parent)
+    : QAbstractListModel(parent), nonogram_{nullptr} {}
+
+int NonogramFieldModel::rowCount(const QModelIndex &parent) const {
+  if (parent.isValid() || !nonogram_) {
+    return 0;
+  } else {
+    return nonogram_->GetFieldWidth() * nonogram_->GetFieldHeight();
+  }
+}
+
+QVariant NonogramFieldModel::data(const QModelIndex &index, int role) const {
+  if (!index.isValid()) {
+    return QVariant();
+  }
+
+  switch (role) {
+  case StateRole: {
+    auto field = nonogram_->getNonogram()->GetField();
+    auto cell_state =
+        field[index.row() / field[0].size()][index.row() % field[0].size()];
+    switch (cell_state) {
+    case NonogramCellState::kEmpty: {
+      return State::Empty;
+    }
+    case NonogramCellState::kMarked: {
+      return State::Marked;
+    }
+    case NonogramCellState::kCrossed: {
+      return State::Crossed;
+    }
+    default:
+      break;
+    }
+  }
+  case RowCountRole: {
+    return nonogram_->GetFieldHeight();
+  }
+  case ColumnCountRole: {
+    return nonogram_->GetFieldWidth();
+  }
+  default:
+    return QVariant();
+  }
+}
+
+QHash<int, QByteArray> NonogramFieldModel::roleNames() const {
+  QHash<int, QByteArray> roles = QAbstractListModel::roleNames();
+
+  roles[StateRole] = "state";
+  roles[RowCountRole] = "row_count";
+  roles[ColumnCountRole] = "column_count";
+
+  return roles;
+}
+
+bool NonogramFieldModel::setData(const QModelIndex &index,
+                                 const QVariant &value, int role) {
+  if (!index.isValid()) {
+    return false;
+  }
+
+  switch (role) {
+  case StateRole: {
+    auto state = value.value<State>();
+    auto nonogram_state = NonogramCellState::kEmpty;
+    switch (state) {
+    case State::Empty: {
+      nonogram_state = NonogramCellState::kEmpty;
+      break;
+    }
+    case State::Marked: {
+      nonogram_state = NonogramCellState::kMarked;
+      break;
+    }
+    case State::Crossed: {
+      nonogram_state = NonogramCellState::kCrossed;
+      break;
+    }
+    default: { return false; }
+    }
+    auto field = nonogram_->getNonogram()->GetField();
+    auto row = index.row() / nonogram_->GetFieldWidth();
+    auto column = index.row() % nonogram_->GetFieldWidth();
+    nonogram_->getNonogram()->SetNonogramCellState(row, column, nonogram_state);
+    break;
+  }
+  case RowCountRole:
+    return false;
+  case ColumnCountRole:
+    return false;
+  }
+
+  emit dataChanged(index, index, QVector<int>() << role);
+  return true;
+}
+
+Qt::ItemFlags NonogramFieldModel::flags(const QModelIndex &index) const {
+  if (!index.isValid()) {
+    return Qt::ItemIsEnabled;
+  }
+
+  return QAbstractListModel::flags(index) | Qt::ItemIsEditable;
+}
+
+NonogramWrapper *NonogramFieldModel::nonogram() const { return nonogram_; }
+
+void NonogramFieldModel::setNonogram(NonogramWrapper *nonogram) {
+  nonogram_ = nonogram;
+}

--- a/nonogram_gui/src/impl/nonogram_rect_model.cpp
+++ b/nonogram_gui/src/impl/nonogram_rect_model.cpp
@@ -1,0 +1,61 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#include "nonogram_rect_model.hpp"
+
+#include <algorithm>
+
+NonogramRectModel::NonogramRectModel(QObject *parent)
+    : QAbstractListModel(parent), nonogram_{nullptr}, max_row_numbers_{0},
+      field_width_{0}, max_column_numbers_{0}, field_height_{0} {}
+
+int NonogramRectModel::rowCount(const QModelIndex &parent) const {
+  if (parent.isValid()) {
+    return 0;
+  }
+
+  return 1;
+}
+
+QVariant NonogramRectModel::data(const QModelIndex &index, int role) const {
+  if (!index.isValid()) {
+    return QVariant();
+  }
+
+  switch (role) {
+  case MaxRowNumbersRole: {
+    return max_row_numbers_;
+  }
+  case FieldWidthRole:
+    return field_width_;
+  case MaxColumnNumbersRole:
+    return max_column_numbers_;
+  case FieldHeightRole:
+    return field_height_;
+  default:
+    return QVariant();
+  }
+
+  return QVariant();
+}
+
+QHash<int, QByteArray> NonogramRectModel::roleNames() const {
+  QHash<int, QByteArray> roles = QAbstractListModel::roleNames();
+  roles[MaxRowNumbersRole] = "max_row_numbers";
+  roles[FieldWidthRole] = "field_width";
+  roles[MaxColumnNumbersRole] = "max_column_numbers";
+  roles[FieldHeightRole] = "field_height";
+
+  return roles;
+}
+
+NonogramWrapper *NonogramRectModel::nonogram() const { return nonogram_; }
+
+void NonogramRectModel::setNonogram(NonogramWrapper *nonogram) {
+  nonogram_ = nonogram;
+
+  field_height_ = nonogram_->GetFieldHeight();
+  field_width_ = nonogram_->GetFieldWidth();
+
+  max_row_numbers_ = nonogram_->GetMaxRowNumbers();
+  max_column_numbers_ = nonogram_->GetMaxColumnNumbers();
+}

--- a/nonogram_gui/src/impl/nonogram_wrapper.cpp
+++ b/nonogram_gui/src/impl/nonogram_wrapper.cpp
@@ -1,0 +1,49 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#include "nonogram_wrapper.hpp"
+
+NonogramWrapper::NonogramWrapper(const std::shared_ptr<INonogram> &nonogram,
+                                 QObject *parent)
+    : QObject{parent}, nonogram_{nonogram},
+      field_width_{nonogram_->GetColumns()},
+      field_height_{nonogram_->GetRows()},
+      max_row_numbers_([&nonogram]() -> quint8 {
+        auto field_height = nonogram->GetRows();
+        auto max_row_numbers = nonogram->GetRowNumbers(0).size();
+
+        for (size_t i = 0; i < field_height; ++i) {
+          auto row_numbers_size = nonogram->GetRowNumbers(i).size();
+          if (max_row_numbers < row_numbers_size) {
+            max_row_numbers = row_numbers_size;
+          }
+        }
+        return max_row_numbers;
+      }()),
+      max_column_numbers_{[&nonogram]() -> quint8 {
+        auto field_width = nonogram->GetColumns();
+        auto max_column_numbers = nonogram->GetColumnNumbers(0).size();
+
+        for (size_t i = 0; i < field_width; ++i) {
+          auto column_numbers_size = nonogram->GetColumnNumbers(i).size();
+          if (max_column_numbers < column_numbers_size) {
+            max_column_numbers = column_numbers_size;
+          }
+        }
+        return max_column_numbers;
+      }()} {}
+
+const std::shared_ptr<INonogram> NonogramWrapper::getNonogram() const {
+  return nonogram_;
+}
+
+const quint8 NonogramWrapper::GetFieldWidth() const { return field_width_; }
+
+const quint8 NonogramWrapper::GetFieldHeight() const { return field_height_; }
+
+const quint8 NonogramWrapper::GetMaxRowNumbers() const {
+  return max_row_numbers_;
+}
+
+const quint8 NonogramWrapper::GetMaxColumnNumbers() const {
+  return max_column_numbers_;
+}

--- a/nonogram_gui/src/impl/row_numbers_model.cpp
+++ b/nonogram_gui/src/impl/row_numbers_model.cpp
@@ -1,0 +1,66 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#include "row_numbers_model.hpp"
+
+#include <QString>
+
+RowNumbersModel::RowNumbersModel(QObject *parent)
+    : QAbstractListModel(parent), nonogram_{nullptr} {}
+
+int RowNumbersModel::rowCount(const QModelIndex &parent) const {
+  if (parent.isValid()) {
+    return 0;
+  }
+
+  return max_row_numbers_ * static_cast<quint8>(row_numbers_.size());
+}
+
+QVariant RowNumbersModel::data(const QModelIndex &index, int role) const {
+  if (!index.isValid()) {
+    return QVariant();
+  }
+
+  switch (role) {
+  case MaxRowNumbersRole:
+    return max_row_numbers_;
+  case FieldHeightRole:
+    return static_cast<quint8>(row_numbers_.size());
+  case RowNumberTextRole: {
+    auto row = index.row() / max_row_numbers_;
+    auto column = index.row() % max_row_numbers_;
+    auto max_row_size = row_numbers_[row].size();
+
+    return (max_row_numbers_ - column) > max_row_size
+               ? ""
+               : QString::number(
+                     row_numbers_[row][max_row_numbers_ - column - 1]);
+  }
+  default:
+    return QVariant();
+  }
+
+  return QVariant();
+}
+
+QHash<int, QByteArray> RowNumbersModel::roleNames() const {
+  QHash<int, QByteArray> roles = QAbstractListModel::roleNames();
+
+  roles[MaxRowNumbersRole] = "max_row_numbers";
+  roles[FieldHeightRole] = "field_height";
+  roles[RowNumberTextRole] = "row_number_text";
+
+  return roles;
+}
+
+NonogramWrapper *RowNumbersModel::nonogram() const { return nonogram_; }
+
+void RowNumbersModel::setNonogram(NonogramWrapper *nonogram) {
+  nonogram_ = nonogram;
+
+  auto field_height = nonogram_->GetFieldHeight();
+  max_row_numbers_ = nonogram_->GetMaxRowNumbers();
+
+  for (size_t i = 0; i < field_height; ++i) {
+    row_numbers_.push_back(nonogram_->getNonogram()->GetRowNumbers(i));
+  }
+}

--- a/nonogram_gui/src/incl/column_numbers_model.hpp
+++ b/nonogram_gui/src/incl/column_numbers_model.hpp
@@ -1,0 +1,66 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_COLUMN_NUMBERS_MODEL_HPP_
+#define NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_COLUMN_NUMBERS_MODEL_HPP_
+
+/**
+ * @brief The class describes model for the QML component, which repesents part
+ * of the nonogram field with column numbers.
+ */
+
+#include <QAbstractListModel>
+#include <QtGlobal>
+
+#include <vector>
+
+#include "nonogram_wrapper.hpp"
+
+class ColumnNumbersModel : public QAbstractListModel {
+  Q_OBJECT
+  Q_PROPERTY(NonogramWrapper *nonogram READ nonogram WRITE setNonogram)
+
+public:
+  enum Roles {
+    MaxColumnNumbersRole = Qt::UserRole + 1,
+    FieldWidthRole,
+    ColumnNumberTextRole,
+  };
+
+  explicit ColumnNumbersModel(QObject *parent = 0);
+
+  int rowCount(const QModelIndex &parent) const override;
+  QVariant data(const QModelIndex &index, int role) const override;
+  QHash<int, QByteArray> roleNames() const override;
+
+  /**
+   * @brief The method returns pointer to the nonogram wrapper object.
+   *
+   * @return Pointer to the nonogram wrapper object.
+   */
+  NonogramWrapper *nonogram() const;
+
+  /**
+   * @brief The method sets pointer to the nonogram wrapper object.
+   *
+   * nonogram  Pointer to the nonogram wrapper object.
+   */
+  void setNonogram(NonogramWrapper *nonogram);
+
+private:
+  /**
+   * @brief Pointer to nonogram wrapper object.
+   */
+  NonogramWrapper *nonogram_;
+
+  /**
+   * @brief Vector of column numbers vectors.
+   */
+  std::vector<std::vector<uint8_t>> column_numbers_;
+
+  /**
+   * @brief Max count of column numbers in one column.
+   */
+  quint8 max_column_numbers_;
+};
+
+#endif // NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_COLUMN_NUMBERS_MODEL_HPP_

--- a/nonogram_gui/src/incl/nonogram_field_model.hpp
+++ b/nonogram_gui/src/incl/nonogram_field_model.hpp
@@ -1,0 +1,64 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_NONOGRAM_FIELD_MODEL_HPP_
+#define NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_NONOGRAM_FIELD_MODEL_HPP_
+
+/**
+ * @brief The class describes model for the QML component, which repesents part
+ * the nonogram field.
+ */
+
+#include <QAbstractListModel>
+
+#include "nonogram_cell_state.hpp"
+#include "nonogram_wrapper.hpp"
+
+class NonogramFieldModel : public QAbstractListModel {
+  Q_OBJECT
+  Q_PROPERTY(NonogramWrapper *nonogram READ nonogram WRITE setNonogram)
+
+public:
+  enum Roles {
+    StateRole = Qt::UserRole + 1,
+    RowCountRole,
+    ColumnCountRole,
+  };
+
+  enum State {
+    Empty,
+    Marked,
+    Crossed,
+  };
+  Q_ENUM(State);
+
+  explicit NonogramFieldModel(QObject *parent = 0);
+
+  int rowCount(const QModelIndex &parent) const override;
+  QVariant data(const QModelIndex &index, int role) const override;
+  QHash<int, QByteArray> roleNames() const override;
+  bool setData(const QModelIndex &index, const QVariant &value,
+               int role) override;
+  Qt::ItemFlags flags(const QModelIndex &index) const override;
+
+  /**
+   * @brief The method returns pointer to the nonogram wrapper object.
+   *
+   * @return Pointer to the nonogram wrapper object.
+   */
+  NonogramWrapper *nonogram() const;
+
+  /**
+   * @brief The method sets pointer to the nonogram wrapper object.
+   *
+   * nonogram  Pointer to the nonogram wrapper object.
+   */
+  void setNonogram(NonogramWrapper *nonogram);
+
+private:
+  /**
+   * @brief Pointer to nonogram wrapper object.
+   */
+  NonogramWrapper *nonogram_;
+};
+
+#endif // NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_NONOGRAM_FIELD_MODEL_HPP_

--- a/nonogram_gui/src/incl/nonogram_rect_model.hpp
+++ b/nonogram_gui/src/incl/nonogram_rect_model.hpp
@@ -1,0 +1,79 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_NONOGRAM_RECT_MODEL_HPP_
+#define NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_NONOGRAM_RECT_MODEL_HPP_
+
+/**
+ * @brief The class describes model for the QML component, which repesents
+ * rectangles for the nonogram field parts.
+ */
+
+#include <QAbstractListModel>
+#include <QtGlobal>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "nonogram_wrapper.hpp"
+
+class NonogramRectModel : public QAbstractListModel {
+  Q_OBJECT
+  Q_PROPERTY(NonogramWrapper *nonogram READ nonogram WRITE setNonogram)
+
+public:
+  enum Roles {
+    MaxRowNumbersRole = Qt::UserRole + 1,
+    FieldWidthRole,
+    MaxColumnNumbersRole,
+    FieldHeightRole,
+  };
+
+  explicit NonogramRectModel(QObject *parent = 0);
+
+  int rowCount(const QModelIndex &parent) const override;
+  QVariant data(const QModelIndex &index, int role) const override;
+  QHash<int, QByteArray> roleNames() const override;
+
+  /**
+   * @brief The method returns pointer to the nonogram wrapper object.
+   *
+   * @return Pointer to the nonogram wrapper object.
+   */
+  NonogramWrapper *nonogram() const;
+
+  /**
+   * @brief The method sets pointer to the nonogram wrapper object.
+   *
+   * nonogram  Pointer to the nonogram wrapper object.
+   */
+  void setNonogram(NonogramWrapper *nonogram);
+
+private:
+  /**
+   * @brief Pointer to nonogram wrapper object.
+   */
+  NonogramWrapper *nonogram_;
+
+  /**
+   * @brief Max count of row numbers in one row.
+   */
+  quint8 max_row_numbers_;
+
+  /**
+   * @brief Count of the main nonogram field columns.
+   */
+  quint8 field_width_;
+
+  /**
+   * @brief Max count of column numbers in one column.
+   */
+  quint8 max_column_numbers_;
+
+  /**
+   * @brief Count of the main nonogram field rows.
+   */
+  quint8 field_height_;
+};
+
+#endif // NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_NONOGRAM_RECT_MODEL_HPP_

--- a/nonogram_gui/src/incl/nonogram_wrapper.hpp
+++ b/nonogram_gui/src/incl/nonogram_wrapper.hpp
@@ -1,0 +1,87 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_NONOGRAM_WRAPPER_HPP_
+#define NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_NONOGRAM_WRAPPER_HPP_
+
+/**
+ * @brief The class describes qt wrapper for the i_nonogram object.
+ */
+
+#include <QObject>
+
+#include <memory>
+
+#include "nonogram_factory.hpp"
+
+class NonogramWrapper : public QObject {
+  Q_OBJECT
+
+public:
+  explicit NonogramWrapper(const std::shared_ptr<INonogram> &nonogram,
+                           QObject *parent = nullptr);
+
+  /**
+   * @brief The method returns pointer to the i_nonogram object.
+   *
+   * @return Pointer to the i_nonogram object.
+   */
+  const std::shared_ptr<INonogram> getNonogram() const;
+
+  /**
+   * @brief The method returns count of the columns of the nonogram.
+   *
+   * @return Count of the columns of the nonogram.
+   */
+  const quint8 GetFieldWidth() const;
+
+  /**
+   * @brief The method returns count of the rows of the nonogram.
+   *
+   * @return Count of the rows of the nonogram.
+   */
+  const quint8 GetFieldHeight() const;
+
+  /**
+   * @brief The method returns max count of row numbers in one row of the
+   * nonogram.
+   *
+   * @return Max count of row numbers in one row.
+   */
+  const quint8 GetMaxRowNumbers() const;
+
+  /**
+   * @brief The method returns max count of column numbers in one column of the
+   * nonogram.
+   *
+   * @return Max count of column numbers in one column.
+   */
+  const quint8 GetMaxColumnNumbers() const;
+
+private:
+  /**
+   * @brief Pointer to the i_nonogram object.
+   */
+  const std::shared_ptr<INonogram> nonogram_;
+
+  /**
+   * @brief Count of the main nonogram field columns.
+   */
+  const quint8 field_width_;
+
+  /**
+   * @brief Count of the main nonogram field rows.
+   */
+  const quint8 field_height_;
+
+  /**
+   * @brief Max count of row numbers in one row.
+   */
+  const quint8 max_row_numbers_;
+
+  /**
+   * @brief Max count of column numbers in one column.
+   */
+  const quint8 max_column_numbers_;
+};
+
+#endif // NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_NONOGRAM_WRAPPER_HPP_

--- a/nonogram_gui/src/incl/row_numbers_model.hpp
+++ b/nonogram_gui/src/incl/row_numbers_model.hpp
@@ -1,0 +1,66 @@
+/*Copyright 2020 Alex Bieliakov*/
+
+#ifndef NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_ROW_NUMBERS_MODEL_HPP_
+#define NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_ROW_NUMBERS_MODEL_HPP_
+
+/**
+ * @brief The class describes model for the QML component, which repesents part
+ * of the nonogram field with column numbers.
+ */
+
+#include <QAbstractListModel>
+#include <QtGlobal>
+
+#include <vector>
+
+#include "nonogram_wrapper.hpp"
+
+class RowNumbersModel : public QAbstractListModel {
+  Q_OBJECT
+  Q_PROPERTY(NonogramWrapper *nonogram READ nonogram WRITE setNonogram)
+
+public:
+  enum Roles {
+    MaxRowNumbersRole = Qt::UserRole + 1,
+    FieldHeightRole,
+    RowNumberTextRole,
+  };
+
+  explicit RowNumbersModel(QObject *parent = 0);
+
+  int rowCount(const QModelIndex &parent) const override;
+  QVariant data(const QModelIndex &index, int role) const override;
+  QHash<int, QByteArray> roleNames() const override;
+
+  /**
+   * @brief The method returns pointer to the nonogram wrapper object.
+   *
+   * @return Pointer to the nonogram wrapper object.
+   */
+  NonogramWrapper *nonogram() const;
+
+  /**
+   * @brief The method sets pointer to the nonogram wrapper object.
+   *
+   * nonogram  Pointer to the nonogram wrapper object.
+   */
+  void setNonogram(NonogramWrapper *nonogram);
+
+private:
+  /**
+   * @brief Pointer to nonogram wrapper object.
+   */
+  NonogramWrapper *nonogram_;
+
+  /**
+   * @brief Vector of column numbers vectors.
+   */
+  std::vector<std::vector<uint8_t>> row_numbers_;
+
+  /**
+   * @brief Max count of row numbers in one row.
+   */
+  quint8 max_row_numbers_;
+};
+
+#endif // NONOGRAM_GAME_NONOGRAM_GUI_SRC_INCL_ROW_NUMBERS_MODEL_HPP_


### PR DESCRIPTION
The project implements simple gui for nonogram on the Qt/QML. It
displays the nonogram field and responds to mouse clicks. Currently
nonogram hardcoded to the main function.
Also modified log for change state in order to print new state of the cell.